### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,13 +1,13 @@
-Qt1110 KEYWORD1
-QTouch KEYWORD1
-configure KEYWORD2
-pause KEYWORD2
-resume KEYWORD2
-reset KEYWORD2
-test KEYWORD2
-validate KEYWORD2
-getAllKeys KEYWORD2
-getKey KEYWORD2
-calibrate KEYWORD2
-getStatus KEYWORD2
+Qt1110	KEYWORD1
+QTouch	KEYWORD1
+configure	KEYWORD2
+pause	KEYWORD2
+resume	KEYWORD2
+reset	KEYWORD2
+test	KEYWORD2
+validate	KEYWORD2
+getAllKeys	KEYWORD2
+getKey	KEYWORD2
+calibrate	KEYWORD2
+getStatus	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords